### PR TITLE
Bundler-agnostic CommonJS using prepublish script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+/build/

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -1,15 +1,8 @@
 'use strict';
 
-var functionBody = [
-    '"use strict"',
-    'var self = {};',
-    require('fs').readFileSync(require.resolve('whatwg-fetch'), 'utf8'),
-    'return self.fetch;'
-].join('\n');
-
 module.exports = function fetchPonyfill(options) {
     var Promise = options && options.Promise || window.Promise;
     var XMLHttpRequest = options && options.XMLHttpRequest || window.XMLHttpRequest;
 
-    return new Function('Promise', 'XMLHttpRequest', functionBody)(Promise, XMLHttpRequest);
+    return require('./build/whatwg-fetch-patched')(Promise, XMLHttpRequest);
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "fetch-ponyfill",
   "version": "0.9.0",
-  "description": "A ponyfill (doesn't overwrite the native fetch) for the Fetch specification https://fetch.spec.whatwg.org.",
+  "description": "An isomorphic ponyfill (doesn't overwrite the native fetch) for the Fetch specification https://fetch.spec.whatwg.org.",
   "main": "fetch-node.js",
   "browser": "fetch-browser.js",
+  "files": [
+    "*.js",
+    "build/*.js"
+  ],
   "scripts": {
+    "prepublish": "mkdir -p build && node scripts/patch-whatwg-fetch.js > build/whatwg-fetch-patched.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Mark Stanley Everitt",
@@ -14,13 +19,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "brfs": "1.4.0",
-    "node-fetch": "1.5.1",
-    "whatwg-fetch": "0.9.0"
+    "node-fetch": "1.5.1"
   },
-  "browserify": {
-    "transform": [
-      "brfs"
-    ]
+  "devDependencies": {
+    "whatwg-fetch": "0.9.0"
   }
 }

--- a/scripts/patch-whatwg-fetch.js
+++ b/scripts/patch-whatwg-fetch.js
@@ -1,0 +1,24 @@
+// `whatwg-fetch` is implemented as a polyfill. To avoid modifying the global
+// object, we patch that implementation.
+//
+// We do this in an `npm prepublish` script, which allows the built package to
+// be consumed as a bundler-agnostic ordinary CommonJS module.
+
+var moduleBody = [
+    "'use strict'",
+    '',
+    '//',
+    '// Generated from whatwg-fetch by fetch-ponyfill.',
+    '//',
+    '',
+    'module.exports = function (Promise, XMLHttpRequest) {',
+    '',
+    'var self = {};',
+    '',
+    require('fs').readFileSync(require.resolve('whatwg-fetch'), 'utf8'),
+    'return self.fetch;',
+    '',
+    '};'
+].join('\n');
+
+console.log(moduleBody);


### PR DESCRIPTION
Remove dependency on brfs and add Webpack support.

It's a little tricky to test a package with a prepublish script without actually publishing it. I used `npm pack` and then uncompressed the file, and my Node-based tests work fine. Do you have an easy way to test the browser version? I'll work on adding browser-based tests next.

Depends on #4