### PR TITLE
Builds a UMD file for the browser when publishing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Release assets
+build

--- a/build.js
+++ b/build.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function indent(line) {
+    return line === '' ? '' : '      ' + line;
+}
+
+var fs = require('fs');
+
+// Get the fetch source as a string.
+var whatwgFetchSource = fs.readFileSync(require.resolve('whatwg-fetch'), 'utf8');
+
+// Get the wrapper source as a string.
+var wrapperSource = fs.readFileSync(require.resolve('./fetch-browser'), 'utf8');
+
+// Indent and place the fetch source inside the wrapper.
+var indented = whatwgFetchSource.split('\n').map(indent).join('\n');
+var builtSource = wrapperSource.replace('// {{whatwgFetch}}', indented);
+
+console.log(builtSource);

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -1,15 +1,26 @@
-'use strict';
+(function () {
+  'use strict';
+  
+  function fetchPonyfill(options) {
+    var Promise = options && options.Promise || self.Promise;
+    var XMLHttpRequest = options && options.XMLHttpRequest || self.XMLHttpRequest;
+  
+    return (function () {
+      var self = {};
 
-var functionBody = [
-    '"use strict"',
-    'var self = {};',
-    require('fs').readFileSync(require.resolve('whatwg-fetch'), 'utf8'),
-    'return self.fetch;'
-].join('\n');
+// {{whatwgFetch}}
 
-module.exports = function fetchPonyfill(options) {
-    var Promise = options && options.Promise || window.Promise;
-    var XMLHttpRequest = options && options.XMLHttpRequest || window.XMLHttpRequest;
+      return self.fetch;
+    }());
+  }
 
-    return new Function('Promise', 'XMLHttpRequest', functionBody)(Promise, XMLHttpRequest);
-};
+  if (typeof define === 'function' && define.amd) {
+    define(function () {
+      return fetchPonyfill;
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = fetchPonyfill;
+  } else {
+    self.fetchPonyfill = fetchPonyfill;
+  }
+}());

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.9.0",
   "description": "A ponyfill (doesn't overwrite the native fetch) for the Fetch specification https://fetch.spec.whatwg.org.",
   "main": "fetch-node.js",
-  "browser": "fetch-browser.js",
+  "browser": "build/fetch-browser.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "rimraf build && mkdirp build && node build.js > build/fetch-browser.js",
+    "prepublish": "npm run build"
   },
   "author": "Mark Stanley Everitt",
   "repository": {
@@ -14,13 +16,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "brfs": "1.4.0",
-    "node-fetch": "1.5.1",
+    "node-fetch": "1.5.1"
+  },
+  "devDependencies": {
+    "mkdirp": "0.5.1",
+    "rimraf": "2.5.2",
     "whatwg-fetch": "0.9.0"
   },
-  "browserify": {
-    "transform": [
-      "brfs"
-    ]
-  }
+  "files": [
+    "fetch-node.js",
+    "build/fetch-browser.js"
+  ]
 }


### PR DESCRIPTION
This PR coaxes browserify into making a standalone build. This allows the built file to be used in AMD environments as well as a browser global.

@paulmelnikow This is an alternative to #5.