### PR TITLE
Fix fetch not being bound to window anymore

### DIFF
--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -12,7 +12,7 @@
 // {{whatwgFetch}}
 
       return {
-        fetch: self.fetch,
+        fetch: self.fetch.bind(global),
         Headers: self.Headers,
         Request: self.Request,
         Response: self.Response

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -17,7 +17,7 @@
 // {{whatwgFetch}}
 
       return {
-        fetch: self.fetch.bind(global),
+        fetch: self.fetch,
         Headers: self.Headers,
         Request: self.Request,
         Response: self.Response

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -7,7 +7,12 @@
     var global = self;
 
     return (function () {
-      var self = Object.create(global, {fetch: {value: undefined}});
+      var self = Object.create(global, {
+        fetch: {
+          value: undefined,
+          writable: true
+        }
+      });
 
 // {{whatwgFetch}}
 

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -4,9 +4,10 @@
   function fetchPonyfill(options) {
     var Promise = options && options.Promise || self.Promise;
     var XMLHttpRequest = options && options.XMLHttpRequest || self.XMLHttpRequest;
+    var global = self;
 
     return (function () {
-      var self = {};
+      var self = Object.create(global);
 
 // {{whatwgFetch}}
 


### PR DESCRIPTION
#16 actually breaks usage in the browser for me, because the context for the native fetch isn't window anymore after the Object.create(self). 

See https://stackoverflow.com/questions/9677985/uncaught-typeerror-illegal-invocation-in-chrome for some simple illustrations of this problem.

This PR however highlights another problem: The tests don't work.

Currently on master, the webpack tests don't compile properly or something, because the bundle that is created has issues with sinon.  
The browserify tests however have another problem: They always run the non-native version of fetch for me. With this PR they use native when available and this then breaks all tests except the first one in each subset.  
I didn't really look into these though. Can you take a look?