### PR TITLE
Add Webpack usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When used in Node, delegates to `node-fetch` instead.
 
 ## Usage
 
-### RequireJS
+### Browserify
 
 ```javascript
 const {fetch, Request, Response, Headers} = require('fetch-ponyfill')(options);

--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@ When used in Node, delegates to `node-fetch` instead.
 
 ## Usage
 
+### RequireJS
+
 ```javascript
 const {fetch, Request, Response, Headers} = require('fetch-ponyfill')(options);
 ```
 
-where options is an object with the following optional properties:
+### Webpack
+
+```javascript
+import fetchPonyfill from 'fetch-ponyfill';
+const {fetch, Request, Response, Headers} = fetchPonyfill(options);
+```
+
+### Options
+
+Where `options` is an object with the following optional properties:
 
 | option | description |
 | ------ | ----------- |


### PR DESCRIPTION
I spent a bit longer than I should've, trying to figure out how exactly to import & use this package via Webpack, and realized finally I'd totally glossed over the actual function call at the end of your RequireJS usage example. A slight tweak to the Usage in README would make it a tad bit more obvious for Webpack integration.