### PR TITLE
fix(Typescript): wrong typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,19 @@
-declare module "fetch-ponyfill" {
-    export default function fetchPonyfill(options?: FetchPonyfill.BootstrapOptions): FetchPonyfill.BootstrapRetVal;
+declare module 'fetch-ponyfill' {
+  const pony = FetchPonyfill.fetchPonyfill;
+  export = pony;
 }
 
 declare namespace FetchPonyfill {
-    interface BootstrapOptions {
-        Promise?: Function;
-        XMLHttpRequest?: Function;
-    }
+  function fetchPonyfill(options?: BootstrapOptions): BootstrapRetVal;
+  interface BootstrapOptions {
+    Promise?: Function;
+    XMLHttpRequest?: Function;
+  }
 
-    interface BootstrapRetVal {
-        fetch: typeof fetch,
-        Headers: typeof Headers,
-        Request: typeof Request,
-        Response: typeof Response
-    }
+  interface BootstrapRetVal {
+    fetch: typeof fetch;
+    Headers: typeof Headers;
+    Request: typeof Request;
+    Response: typeof Response;
+  }
 }


### PR DESCRIPTION
the typescript definition was incorrectly defined, in the js code, there isn't any default export, we can't use follow code in typescript, it works with babel because babel tries to guess the export type.
```js
import fetchPonyfill from 'fetch-ponyfill';
```
but in generated ts code, it will try to execute ``fetchPonyfill.default()`` instead of ``fetchPonyfill()``
