### PR TITLE
declare default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export = fetchPonyfill;
+export default fetchPonyfill;
 
 declare function fetchPonyfill(options?: fetchPonyfill.BootstrapOptions): fetchPonyfill.BootstrapRetVal;
 


### PR DESCRIPTION
I had to add this in order to get the module to work with typescript.

From what I can see the tests still pass; however I'm not an expert on these things so if this would break anything for anyone else, please let me know.

I had a look through some of the old pull requests, and it seemed like this is related to a [previous pull request](https://github.com/qubyte/fetch-ponyfill/pull/86).

Sorry if this ends up just being an annoyance for someone to have to reject this; I just thought that as it helped me, I'd put it up here and see if there's a good reason why this shouldn't be changed.

Thanks for taking a look!