### PR TITLE
node/webpack fix w/ support for tests

### DIFF
--- a/fetch-node.js
+++ b/fetch-node.js
@@ -2,7 +2,10 @@
 
 var fetch = require('node-fetch');
 
-function wrapFetchForNode(fetch) {
+function wrapFetchForNode(fetchModule) {
+  // Support webpack module import weirdness.
+  var fetch = fetchModule.default ? fetchModule.default : fetchModule;
+
   // Support schemaless URIs on the server for parity with the browser.
   // https://github.com/matthew-andrews/isomorphic-fetch/pull/10
   return function (u, options) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:browserify": "testem ci",
     "pretest:webpack": "npm run build && webpack --mode development tests/fetch-browser.spec.js -o build/browser-test-bundle.js",
     "test:webpack": "testem ci",
+    "pretest:webpack:node": "webpack --mode development --target node tests/fetch-node.spec.js -o build/node-test-bundle.js",
+    "test:webpack:node": "mocha build/node-test-bundle.js",
     "build": "rimraf build && mkdirp build && node build.js > build/fetch-browser.js",
     "prepublishOnly": "npm run build"
   },

--- a/tests/fetch-node.spec.js
+++ b/tests/fetch-node.spec.js
@@ -6,7 +6,7 @@ var fetchWrapper = require('../fetch-node');
 var URL = require('url').URL;
 var nock = require('nock');
 var assert = require('assert');
-var ThenPromise = require('promise');
+var ThenPromise = Promise;
 
 var good = 'hello world. 你好世界。';
 var bad = 'good bye cruel world. 再见残酷的世界。';


### PR DESCRIPTION
fix for node webpack environments, solution based off https://github.com/qubyte/fetch-ponyfill/pull/239 but with added support for tests.

Please pay special attention to fetch-node.spec.js line #9--as I don't understand what's going on with the Promise context but that change resulted in all tests passing.  I may be cheating by making that change, as node-fetch probably uses node's native Promise implementation so it's making the tests invalid.  If that's the case--then I'm not sure how to fix it.

Edit:  If this is accepted, we need to add the new tests to be included in github's PR checks. 
