### PR TITLE
Update node-fetch to 2.6.7

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+# 7.2.0
+
+- Updates node-fetch to ~[2.6.7](https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7) - Security patch release
+
 # 7.1.0
 
 - Updates whatwg-fetch to 3.5.0 to address an issue with IE11.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,54 +1,54 @@
 # History
 
-# 7.2.0
+## 7.2.0
 
 - Updates node-fetch to ~[2.6.7](https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7) - Security patch release
 
-# 7.1.0
+## 7.1.0
 
 - Updates whatwg-fetch to 3.5.0 to address an issue with IE11.
 
 ## 7.0.0
 
- - Drops support for node 8. Adds node 14 to tests.
- - Updates whatwg-fetch to ~3.4.1.
- - Exposes `DOMException` from whatwg-fetch.
- - Tests against webpack 5 and browserify 17.
+- Drops support for node 8. Adds node 14 to tests.
+- Updates whatwg-fetch to ~3.4.1.
+- Exposes `DOMException` from whatwg-fetch.
+- Tests against webpack 5 and browserify 17.
 
 ## 6.1.0
 
- - Adds a types field to package.json for TypeScript integration.
- - Updates node-fetch to 2.6.0
+- Adds a types field to package.json for TypeScript integration.
+- Updates node-fetch to 2.6.0
 
 ## 6.0.2
 
- - Fixes WHATWG URL object handling when this module is used in Node.
+- Fixes WHATWG URL object handling when this module is used in Node.
 
 ## 6.0.1
 
- - Fixes to the TypeScript declaration file.
+- Fixes to the TypeScript declaration file.
 
 ## 6.0.0
 
- - Adjusts the way the global object is sniffed for use with Metro.
+- Adjusts the way the global object is sniffed for use with Metro.
 
 ## 5.0.0
 
- - Bumps node-fetch from ~1.7.1 to ~2.0.0. This is a potentially breaking
+- Bumps node-fetch from ~1.7.1 to ~2.0.0. This is a potentially breaking
    change. Refer to the node-fetch [upgrade guide](https://github.com/bitinn/node-fetch/blob/master/UPGRADE-GUIDE.md)
    for details.
 
 ## 4.1.0
 
- - Bumps node fetch from ~1.6.0 to ~1.7.1.
- - Bumps whatwg-fetch from ~2.0.1 to ~2.0.3.
+- Bumps node fetch from ~1.6.0 to ~1.7.1.
+- Bumps whatwg-fetch from ~2.0.1 to ~2.0.3.
 
 ## 4.0.0
 
 This release:
 
- - Bumps whatwg-fetch from ~1.0.0 to ~2.0.1.
- - Better handling of self/this for browser fetch (more testing friendly).
+- Bumps whatwg-fetch from ~1.0.0 to ~2.0.1.
+- Better handling of self/this for browser fetch (more testing friendly).
 
 ## 3.0.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "fetch-ponyfill",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fetch-ponyfill",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "~2.6.1"
+        "node-fetch": "~2.6.7"
       },
       "devDependencies": {
         "browserify": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-ponyfill",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "A ponyfill (doesn't overwrite the native fetch) for the Fetch specification https://fetch.spec.whatwg.org.",
   "main": "fetch-node.js",
   "browser": "build/fetch-browser.js",
@@ -31,7 +31,7 @@
     "ponyfill"
   ],
   "dependencies": {
-    "node-fetch": "~2.6.1"
+    "node-fetch": "~2.6.7"
   },
   "devDependencies": {
     "browserify": "^17.0.0",


### PR DESCRIPTION
It's a security patch release: https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7